### PR TITLE
Prevent melon loader from patching harmony twice and cleaned the code

### DIFF
--- a/CVRParamLib/Properties/AssemblyInfo.cs
+++ b/CVRParamLib/Properties/AssemblyInfo.cs
@@ -39,3 +39,4 @@ using MelonLoader;
 [assembly: MelonInfo(typeof(MelonLoaderMod), "CVRParamLib", "1.3.0", "200Tigersbloxed")]
 [assembly: MelonGame("Alpha Blend Interactive", "ChilloutVR")]
 [assembly: MelonOptionalDependencies("BepInEx")]
+[assembly: HarmonyDontPatchAll] // Tell MelonLoader to not call PatchAll() automatically


### PR DESCRIPTION
Was messing around and trying to patch some methods and came across with this solution to avoid MelonLoader to auto patch (resulting in patching twice if you manually call PatchAll).

Note that I'm very very inexperience with C# and RE, so if I deleted something that was needed sorry ;_;

Edit: I don't know why the diff looks so bad, the changes weren't that many ;_;