### PR TITLE
Added a stub to improve the performance of detecting parameter changes

### DIFF
--- a/CVRParamLib/CVRParameterInstance.cs
+++ b/CVRParamLib/CVRParameterInstance.cs
@@ -150,6 +150,8 @@ public class CVRParameterInstance
 
     internal void UpdateParameter(string name, float value) => PlayerSetup.changeAnimatorParam(name, value);
 
+    internal CVRAnimatorManager? GetAnimatorManager() => _animatorManager;
+
     public enum LogLevel
     {
         Debug,

--- a/CVRParamLib/ModPluginLoader.cs
+++ b/CVRParamLib/ModPluginLoader.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System;
 using System.IO;
@@ -213,5 +213,20 @@ internal class HarmonyPatches
     {
         [HarmonyPrefix]
         static void Recycle(AvatarDetails_t __instance) => AvatarHandler.CacheAvatar(__instance);
+    }
+    
+    [HarmonyPatch(typeof(PlayerSetup), "changeAnimatorParam")]
+    class ChangeAnimatorParam_Hook
+    {
+        [HarmonyPostfix]
+        static void changeAnimatorParam(string name, float value) {
+            CVRParameterInstance.WriteLog(CVRParameterInstance.LogLevel.Debug,
+                $"Parameter {name} changed to {value}.");
+            // Todo: Use this to drive parameter changes instead of checking in update loop
+            // Note1: Parameters driven by the CVR Stream component will spam the hell out of this method.
+            // Note2: When a slider is being used, will also spam as well.
+            // So a check with a dictionary far values change is advised, also for comparision of floats I would
+            // recommend using this: https://docs.unity3d.com/ScriptReference/Mathf.Approximately.html
+        }
     }
 }


### PR DESCRIPTION
I was messing around with harmony and found this method is called every time a parameter changes. I think it would be better for performance.

I was going to go the extra mile and merge it on your implementation, but before I changed a ton of code I rather have your input. Is this something you would like to implement, or you rather me to do it? I am not very experienced in C# and I'm pretty sure you wouldn't like my code.
